### PR TITLE
Version bump to 0.1.6 for PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from distutils.core import setup
 setup(
     name='celery-pubsub',
     packages=['celery_pubsub'],
-    version='0.1.5',
+    version='0.1.6',
     description='A Publish and Subscribe library for Celery',
     author='Samuel GIFFARD',
     author_email='mulugruntz@gmail.com',
     license='MIT',
     url='https://github.com/Mulugruntz/celery-pubsub',
-    download_url='https://github.com/Mulugruntz/celery-pubsub/tarball/0.1.5',
+    download_url='https://github.com/Mulugruntz/celery-pubsub/tarball/0.1.6',
     keywords=['celery', 'publish', 'subscribe', 'pubsub'],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
So that the download_url points to the correct tarball