### PR TITLE
Subscribe to a topic with a decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 dist/*
 build/*
 celery_pubsub.egg-info/*

--- a/celery_pubsub/pubsub.py
+++ b/celery_pubsub/pubsub.py
@@ -92,19 +92,16 @@ def publish_now(topic: str, *args: PA, **kwargs: PK) -> EagerResult[R]:
     return _pubsub_manager.publish_now(topic, *args, **kwargs)
 
 
-def subscribe(
-    topic: str, task: typing.Optional[Task[P, R]] = None
-) -> typing.Optional[typing.Callable[[Task[P, R]], Task[P, R]]]:
-    if task is None:
+def subscribe(topic: str, task: Task[P, R]) -> None:
+    return _pubsub_manager.subscribe(topic, task)
 
-        def _wrapper(task: Task[P, R]) -> Task[P, R]:
-            _pubsub_manager.subscribe(topic, task)
-            return task
 
-        return _wrapper
-    else:
+def subscribe_to(topic: str) -> typing.Callable[[Task[P, R]], Task[P, R]]:
+    def _wrapper(task: Task[P, R]) -> Task[P, R]:
         _pubsub_manager.subscribe(topic, task)
-        return None
+        return task
+
+    return _wrapper
 
 
 def unsubscribe(topic: str, task: Task[P, R]) -> None:

--- a/celery_pubsub/pubsub.py
+++ b/celery_pubsub/pubsub.py
@@ -92,8 +92,19 @@ def publish_now(topic: str, *args: PA, **kwargs: PK) -> EagerResult[R]:
     return _pubsub_manager.publish_now(topic, *args, **kwargs)
 
 
-def subscribe(topic: str, task: Task[P, R]) -> None:
-    return _pubsub_manager.subscribe(topic, task)
+def subscribe(
+    topic: str, task: typing.Optional[Task[P, R]] = None
+) -> typing.Optional[typing.Callable[[Task[P, R]], Task[P, R]]]:
+    if task is None:
+
+        def _wrapper(task: Task[P, R]) -> Task[P, R]:
+            _pubsub_manager.subscribe(topic, task)
+            return task
+
+        return _wrapper
+    else:
+        _pubsub_manager.subscribe(topic, task)
+        return None
 
 
 def unsubscribe(topic: str, task: Task[P, R]) -> None:

--- a/celery_pubsub/pubsub.py
+++ b/celery_pubsub/pubsub.py
@@ -22,6 +22,7 @@ __all__ = [
     "publish",
     "publish_now",
     "subscribe",
+    "subscribe_to",
     "unsubscribe",
 ]
 

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -40,12 +40,12 @@ def test_subscription(job_c: Task[P, str], celery_worker: WorkController) -> Non
 
 
 def test_subscription_decorator(job_c: Task[P, str], celery_worker: WorkController) -> None:
-    from celery_pubsub import publish, subscribe
+    from celery_pubsub import publish, subscribe_to
 
     res = publish("dummy", 4, 8, a15=16, a23=42).get()
     assert sorted(res) == sorted(["e"])
 
-    job_c = subscribe("dummy")(job_c)
+    job_c = subscribe_to("dummy")(job_c)
 
     res = publish("dummy", 4, 8, a15=16, a23=42).get()
     assert sorted(res) == sorted(["e", "c"])

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -39,6 +39,23 @@ def test_subscription(job_c: Task[P, str], celery_worker: WorkController) -> Non
     assert sorted(res) == sorted(["e"])
 
 
+def test_subscription_decorator(job_c: Task[P, str], celery_worker: WorkController) -> None:
+    from celery_pubsub import publish, subscribe
+
+    res = publish("dummy", 4, 8, a15=16, a23=42).get()
+    assert sorted(res) == sorted(["e"])
+
+    job_c = subscribe("dummy")(job_c)
+
+    res = publish("dummy", 4, 8, a15=16, a23=42).get()
+    assert sorted(res) == sorted(["e", "c"])
+
+    unsubscribe("dummy", job_c)
+
+    res = publish("dummy", 4, 8, a15=16, a23=42).get()
+    assert sorted(res) == sorted(["e"])
+
+
 def test_1(celery_worker: WorkController) -> None:
     res = publish("index.low.test", 4, 8, a15=16, a23=42).get()
     assert sorted(res) == sorted(["d", "e", "f", "g"])


### PR DESCRIPTION
Fixes #235 

@Mulugruntz : At first I've tried to implement `subscribe` to be used as both a function and a decorator (see be804ba37c04d00332447aec976a66a2b3cf5133) but it made type hints useless and signature ugly - so I've created a new function `subscribe_to` to be used as a decorator.

I should also update README.md to show an usage example but maybe let's first settle on approach and naming.