### PR TITLE
ci: Move CodeClimate ID from secrets to vars

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
     - name: Code Climate Coverage Action
       uses: paambaati/codeclimate-action@v3.2.0
       env:
-        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        CC_TEST_REPORTER_ID: ${{ vars.CC_TEST_REPORTER_ID }}
       with:
         coverageCommand: coverage xml
         debug: true


### PR DESCRIPTION
According to their documentation, this is not considered a sensitive value.

https://docs.codeclimate.com/docs/finding-your-test-coverage-token#regenerating-a-repos-test-reporter-id